### PR TITLE
Fixed the spacing padding between Print/PDF and the Export buttons.

### DIFF
--- a/src/styles/DashboardPage.css
+++ b/src/styles/DashboardPage.css
@@ -222,19 +222,19 @@
 }
 
 .export-button,
-.print-pdf-button,
-.add-grant-button {
+.print-pdf-button {
   background-color: #7B2CBF;
   color: white !important;
   border: none;
   border-radius: 6px;
-  padding: 12px 20px;
+  padding: 10px 16px;
   font-weight: bold;
   cursor: pointer;
   transition: all 0.3s ease;
   white-space: nowrap;
-  flex-shrink: 0;
-  margin: 0;
+  flex-shrink: 0; 
+  margin-right: 12px;
+  margin-bottom: 10px;
   display: inline-block;
 }
   


### PR DESCRIPTION
closes #33

# Quick Overview of Changes

- Fixed the spacing padding between Print/PDF and the Export buttons


![image](https://github.com/user-attachments/assets/ee1eb80b-7467-4e0d-af4c-f6ff9da29f76)


